### PR TITLE
fix: oklch color formatting

### DIFF
--- a/src/utils/color-helpers.ts
+++ b/src/utils/color-helpers.ts
@@ -47,8 +47,8 @@ export function formatOklchColor(hex: string): string {
   const h = color.h !== undefined ? color.h.toFixed(2) : '0';
 
   if (color.alpha !== undefined && color.alpha !== 1) {
-    return `${l} ${c} ${h} / ${percentageFormat(color.alpha)}`;
+    return `oklch(${l} ${c} ${h} / ${percentageFormat(color.alpha)})`;
   }
 
-  return `${l} ${c} ${h}`;
+  return `oklch(${l} ${c} ${h})`;
 }


### PR DESCRIPTION
## Problem

When selecting the OKLCH color option, styles were not being applied correctly due to improper color value formatting.
fix #9 

## Changes

- Updated formatOklchColor function to wrap color values with oklch() syntax
- Fixed both alpha and non-alpha color value formatting

## Before

```css
/* Invalid CSS - missing function wrapper */
color: 0.65 0.15 180;
color: 0.65 0.15 180 / 80%;
```

## After
```css
/* Valid CSS - proper OKLCH syntax */
color: oklch(0.65 0.15 180);
color: oklch(0.65 0.15 180 / 80%);
```